### PR TITLE
Convert to JabRef 5.x

### DIFF
--- a/app-text/jabref-bin/jabref-bin-4.9999.ebuild
+++ b/app-text/jabref-bin/jabref-bin-4.9999.ebuild
@@ -6,37 +6,29 @@ EAPI=6
 inherit eutils java-pkg-2
 
 DESCRIPTION="Java GUI manages bibliographies in a BibTeX database"
-HOMEPAGE="http://www.jabref.org/"
+HOMEPAGE="https://www.jabref.org/"
 KEYWORDS=""
 
 LICENSE="MIT"
 SLOT="0"
 
-DEPEND="app-arch/unzip"
+DEPEND="app-arch/tar"
 
-RDEPEND="
-		|| (
-		dev-java/oracle-jre-bin:1.8[javafx]
-		dev-java/oracle-jdk-bin:1.8[javafx]
-		)
-		>=virtual/jre-1.8
-		"
+RDEPEND=""
 
 S="${WORKDIR}"
 
 src_unpack() {
 	einfo "Downloading the latest Jabref development snapshot."
 	einfo "Upstream updates these a few times per day."
-	wget "https://builds.jabref.org/master/JabRef--master--latest.jar" -O ${P}.jar || die "wget failed"
-	unzip  ${P}.jar images/external/JabRef-icon-48.png || die "icon extraction failed"
+	wget "http://builds.jabref.org/master/JabRef-portable_linux.tar.gz" -O ${P}.tar.gz || die "wget failed"
+	tar --extract --file=${P}.tar.gz JabRef/bin/JabRef.png || die "icon extraction failed"
 }
 
 src_install() {
-	java-pkg_newjar "${P}.jar"
-	java-pkg_dolauncher "${PN}" --jar "${PN}.jar"
-	newicon images/external/JabRef-icon-48.png JabRef-bin-icon.png
+	newicon JabRef/bin/JabRef.png JabRef-bin-icon.png
 	make_desktop_entry "${PN}" JabRef-bin JabRef-bin-icon Office
-	ewarn "Jabref 4.x will convert old 3.x format .bib databases to a new format."
+	ewarn "Jabref 5.x will convert old 3.x format .bib databases to a new format."
 	ewarn "The conversion is irreversible, backup .bib files before starting Jabref."
-	ewarn "Jabref 4.x is under heavy development and very unstable."
+	ewarn "Jabref 5.x is under heavy development and very unstable."
 }

--- a/app-text/jabref-bin/jabref-bin-4.9999.ebuild
+++ b/app-text/jabref-bin/jabref-bin-4.9999.ebuild
@@ -21,7 +21,7 @@ S="${WORKDIR}"
 src_unpack() {
 	einfo "Downloading the latest Jabref development snapshot."
 	einfo "Upstream updates these a few times per day."
-	wget "http://builds.jabref.org/master/JabRef-portable_linux.tar.gz" -O ${P}.tar.gz || die "wget failed"
+	wget "https://builds.jabref.org/master/JabRef-portable_linux.tar.gz" -O ${P}.tar.gz || die "wget failed"
 	tar --extract --file=${P}.tar.gz JabRef/bin/JabRef.png || die "icon extraction failed"
 }
 


### PR DESCRIPTION
JabRef 5.x switched to Java 11. So, the current ebuild does not work.

The new distribution includes a JRE distribution. This PR is a first step to use it. Since I am not a Gentoo user, can someone take over please?